### PR TITLE
fix: delete pop in mock repository when deleting user in identity service

### DIFF
--- a/identity_service/repository/mock_user_repository.py
+++ b/identity_service/repository/mock_user_repository.py
@@ -1,5 +1,5 @@
 """Mock User Repository"""
-
+from datetime import datetime
 from typing import List
 from uuid import uuid4
 
@@ -221,7 +221,7 @@ class MockUserRepositoryImpl(UserRepositoryInterface):
                 for i in range(len(self._users))
                 if self._users[i].id == user_id and self._users[i].suspended_at is None
             )
-            self._users.pop(index)
+            self._users[index].suspended_at = datetime.now()
         except StopIteration:
             raise ValueNotFoundError("No user found")
 


### PR DESCRIPTION
1) Remove pop when deleting user and set suspended_at to datetime.now() instead 