### PR TITLE
fix: typo in get_invites_by_invitee_id in invite service

### DIFF
--- a/invite_service/repository/mock_invite_repository.py
+++ b/invite_service/repository/mock_invite_repository.py
@@ -245,7 +245,7 @@ class MockInviteRepositoryImpl(InviteRepositoryInterface):
         invites = [
             invite
             for invite in self._invites
-            if invite.id == invitee_id
+            if invite.invitee_id == invitee_id
             and invite.deleted_at is None
             and (invite.status == status if status is not None else True)
         ]


### PR DESCRIPTION
1) Fix typo in method get_invites_by_invitee_id