### PR TITLE
fix: can't create event when pending event has been deleted in invite service

### DIFF
--- a/invite_service/repository/invite_repository_impl.py
+++ b/invite_service/repository/invite_repository_impl.py
@@ -311,7 +311,7 @@ class InviteRepositoryImpl(InviteRepositoryInterface):
 
         db_invite = Invite.from_prisma_invite(prisma_db_invite)
 
-        if db_invite.status == InviteStatus.PENDING:
+        if db_invite.status == InviteStatus.PENDING and db_invite.deleted_at is None:
             raise UniqueError("Invite already exists")
 
         db_invite.deleted_at = None
@@ -340,7 +340,7 @@ class InviteRepositoryImpl(InviteRepositoryInterface):
         )
 
         if db_invites is not None and len(db_invites) > 0:
-            if any([db_invite.status == InviteStatus.PENDING for db_invite in db_invites]):
+            if any([db_invite.status == InviteStatus.PENDING and db_invite.deleted_at is None for db_invite in db_invites]):
                 raise UniqueError("Some invites already exist")
 
             ids = [db_invite.id for db_invite in db_invites]

--- a/invite_service/repository/mock_invite_repository.py
+++ b/invite_service/repository/mock_invite_repository.py
@@ -280,7 +280,7 @@ class MockInviteRepositoryImpl(InviteRepositoryInterface):
                 and self._invites[i].invitee_id == invite.invitee_id
             )
 
-            if self._invites[old_invite_index].status == InviteStatus.PENDING:
+            if self._invites[old_invite_index].status == InviteStatus.PENDING and self._invites[old_invite_index].deleted_at is None:
                 raise UniqueError("Invite already exists")
 
             self._invites[old_invite_index] = invite
@@ -311,7 +311,7 @@ class MockInviteRepositoryImpl(InviteRepositoryInterface):
         db_invites = [(self._invites[i], i) for i in range(len(self._invites)) if self._invites[i].id in invite_ids]
 
         for invite, index in db_invites:
-            if any([invite == InviteStatus.PENDING for invite, _ in db_invites]):
+            if any([invite == InviteStatus.PENDING and invite.deleted_at is None for invite, _ in db_invites]):
                 raise UniqueError("Some invites already exist")
 
             self._invites[index].deleted_at = None


### PR DESCRIPTION
1) Fixed can't create event when pending event has been deleted