### PR TITLE
fix: typo in get_event route and add default value to CreateEventRequest

### DIFF
--- a/gateway/app/routers/events.py
+++ b/gateway/app/routers/events.py
@@ -105,7 +105,7 @@ class CreateEventRequest(BaseModel):
     end: datetime
     description: Optional[str]
     color: Optional[str]
-    repeating_delay: Optional[Interval]
+    repeating_delay: Optional[Interval] = None
 
 
 @router.get("/my/created")
@@ -236,7 +236,7 @@ async def get_my_invited_events(
     return [Event.from_proto(event) for event in invited_events_request.events]
 
 
-@router.get("/{event-id}")
+@router.get("/{event_id}")
 async def get_event(
         event_id: UUID4 | Annotated[str, AfterValidator(lambda x: UUID(x, version=4))],
         user: Annotated[GrpcUser, Depends(auth)],


### PR DESCRIPTION
1) Rename route from /events/{event-id} to /events/{event_id}
2) Add default value of Interval to None in CreateEventRequest