### PR TITLE
Fix: create notification with event returns notification with wrong id

### DIFF
--- a/gateway/app/routers/events.py
+++ b/gateway/app/routers/events.py
@@ -502,7 +502,7 @@ async def create_event(
     if event_data.delay is not None:
         notification = Notification(
             id=uuid4(),
-            event_id=event.id,
+            event_id=created_event.id,
             author_id=user.id,
             enabled=True,
             created_at=datetime.utcnow(),

--- a/gateway/app/routers/notifications.py
+++ b/gateway/app/routers/notifications.py
@@ -321,11 +321,8 @@ async def update_notification_as_author(
 
     stored_notification.start = stored_notification.start.astimezone(tz=utc)
 
-    if modify_notification_request.event_id != stored_notification.event_id:
-        stored_notification.start = event.start.astimezone(tz=utc)
-
     stored_notification.start = convert_event_start_to_notification_start(
-        stored_notification.start,
+        event.start.astimezone(tz=utc),
         modify_notification_request.delay
     )
 


### PR DESCRIPTION
1) Fix create notification with event returns notification with wrong id
2) Fix notification_start did not update when updating notification delay